### PR TITLE
added heartbeat route

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ async fn main() -> std::io::Result<()> {
                     .app_data(json_config)
                     .route(web::post().to(receive_data)),
             ).service(
-                web::resource("/")
+                web::resource("/heartbeat/2/")
                     .route(web::get().to(index)),
             )
     })


### PR DESCRIPTION
Recently I added a route for service-lowmaf-rust to check if the server is alive. 
![image](https://user-images.githubusercontent.com/75449819/213873165-278cb379-c088-41d1-a2cb-0c942ac4932b.png)

The same functionality already existed in service-tie but was not working. I reconfigured the nginx configs to get it to work, and I changed the route path to keep it consistent.
![image](https://user-images.githubusercontent.com/75449819/213873212-0483cbfa-0059-4c92-bd16-589165eeef98.png)
As you can see the same functionality now exists for service-tie